### PR TITLE
use correct framework

### DIFF
--- a/MongoDb.ASP.NETCore3CRUDSample/MongoDb.ASP.NETCore3CRUDSample.csproj
+++ b/MongoDb.ASP.NETCore3CRUDSample/MongoDb.ASP.NETCore3CRUDSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)